### PR TITLE
Fixed estimator test.

### DIFF
--- a/okvis_ceres/test/TestEstimator.cpp
+++ b/okvis_ceres/test/TestEstimator.cpp
@@ -72,6 +72,8 @@ TEST(okvisTestSuite, Estimator) {
     imuParameters.sigma_a_c = 2.0e-3;
     imuParameters.sigma_gw_c = 3.0e-6;
     imuParameters.sigma_aw_c = 2.0e-5;
+    imuParameters.sigma_ba = 0.1;
+    imuParameters.sigma_bg = 0.03;
     imuParameters.tau = 3600.0;
     std::cout << "case " << c % 2 << ", " << c / 2 << std::endl;
 


### PR DESCRIPTION
Not sure if anyone actually uses this test.. But I fixed it. 
Since `sigma_ba` and `sigma_bg` were zero in the test, the resulting information matrix had `inf`and `nan` entries. I set them to the same values as in one of the config files.